### PR TITLE
Fix time summary padding error

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+; http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[{package.json,.travis.yml}]
+indent_style = space
+indent_size = 2

--- a/index.js
+++ b/index.js
@@ -58,9 +58,9 @@ module.exports = (function () {
             startTime: this.utc.start,
             endTime: this.utc.end
         };
-        o.time = parseFloat(o.seconds + '.' + Math.round(o.milliseconds));
+        o.time = Number(((o.seconds * 1000 + o.milliseconds) / 1000).toFixed(3));
         var n = this.name ? this.name + ': ' : '';
-        o.summary = n + o.time.toFixed(3) + ' sec.';
+        o.summary = n + o.time + ' sec.';
         this.result = o;
         return o;
     };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
-    "test": "grunt"
+    "test": "grunt",
+    "lint": "eslint index.js test"
   },
   "repository": {
     "type": "git",
@@ -34,6 +35,7 @@
   },
   "homepage": "https://github.com/onury/perfy#readme",
   "devDependencies": {
+    "eslint": "^2.4.0",
     "grunt": "^0.4.5",
     "grunt-jasmine-nodejs": "^1.4.3"
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "grunt"
   },
   "repository": {
     "type": "git",

--- a/test/perfy.spec.js
+++ b/test/perfy.spec.js
@@ -22,6 +22,16 @@ describe('Test: perfy', function () {
         }, 345);
     });
 
+    it('should return zero pad milliseconds in time and summary', function (done) {
+        perfy.start('m1');
+        setTimeout(function () {
+            var result = perfy.end('m1');
+            expect(result.time).toEqual(Number('0.0' + Math.round(result.milliseconds)));
+            expect(result.summary).toEqual('m1: ' + '0.0' + Math.round(result.milliseconds) + ' sec.');
+            done();
+        }, 15);
+    });
+
     it('should keep/destroy/auto-destroy perf instance', function (done) {
         expect(perfy.exists('m1')).toEqual(false);
         perfy.start('m2', false);


### PR DESCRIPTION
For intervals spanning less that 100ms, time and summary erronously append, rather than prepended zeros.

Ie. 15ms would become 0.150ms.

I've also streamlined the QA process slightly.
