### PR TITLE
add timeInMilliseconds property to result

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,9 @@ module.exports = (function () {
             startTime: this.utc.start,
             endTime: this.utc.end
         };
-        o.time = Number(((o.seconds * 1000 + o.milliseconds) / 1000).toFixed(3));
+        o.timeinMilliseconds = o.seconds * 1000 + o.milliseconds;
+        o.time = Number((o.timeinMilliseconds / 1000).toFixed(3));
+        o.timeinMilliseconds = Number(o.timeinMilliseconds.toFixed(3));
         var n = this.name ? this.name + ': ' : '';
         o.summary = n + o.time + ' sec.';
         this.result = o;

--- a/test/perfy.spec.js
+++ b/test/perfy.spec.js
@@ -15,6 +15,7 @@ describe('Test: perfy', function () {
             var result = perfy.end('m1');
             expect(result).toEqual(jasmine.any(Object));
             expect(result.time).toEqual(jasmine.any(Number));
+            expect(result.timeinMilliseconds).toEqual(jasmine.any(Number));
             expect(result.nanoseconds).toEqual(jasmine.any(Number));
             expect(result.milliseconds).toEqual(jasmine.any(Number));
             expect(perfy.count()).toEqual(0);


### PR DESCRIPTION
Hi,

I would very much like to have a millisecond precision for the complete duration without doing any additional working outside the library.

Is there anything else I can/should do to see this asap on NPM?

Best
Andreas